### PR TITLE
Migrate to pcre2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ AUTOCONFIG=1
 ### if AUTOCONFIG is not active you can manually enable the
 ### optional modules or patches for other plugins
 ifeq ($(AUTOCONFIG),0)
-# if you want to use Perl compatible regular expressions (PCRE) or libtre for
-# unlimited fuzzy searching, uncomment this and set the value to pcre or tre
+# if you want to use Perl compatible regular expressions (PCRE2) or libtre for
+# unlimited fuzzy searching, uncomment this and set the value to pcre2 or tre
 # also have a look at INSTALL for further notes on this
 
-#REGEXLIB = pcre
+#REGEXLIB = pcre2
 
 # uncomment this to enable support for the pin plugin.
 
@@ -87,8 +87,8 @@ export CXXFLAGS = $(call PKGCFG,cxxflags)
 
 ### configuring modules
 ifeq ($(AUTOCONFIG),1)
-	ifeq (exists, $(shell $(PKG_CONFIG) libpcre && echo exists))
-		REGEXLIB = pcre
+	ifeq (exists, $(shell $(PKG_CONFIG) libpcre2 && echo exists))
+		REGEXLIB = pcre2
 	else ifeq (exists, $(shell $(PKG_CONFIG) tre && echo exists))
 		REGEXLIB = tre
 	endif
@@ -137,11 +137,11 @@ endif
 
 OBJS = afuzzy.o blacklist.o changrp.o confdloader.o conflictcheck.o conflictcheck_thread.o distance.o $(PLUGIN).o epgsearchcats.o epgsearchcfg.o epgsearchext.o epgsearchsetup.o  epgsearchsvdrp.o epgsearchtools.o mail.o md5.o menu_announcelist.o menu_blacklistedit.o menu_blacklists.o menu_commands.o menu_conflictcheck.o menu_deftimercheckmethod.o menu_dirselect.o menu_event.o menu_favorites.o menu_main.o menu_myedittimer.o menu_quicksearch.o menu_recsdone.o menu_search.o menu_searchactions.o menu_searchedit.o menu_searchresults.o menu_searchtemplate.o menu_switchtimers.o menu_templateedit.o menu_timersdone.o menu_whatson.o noannounce.o pending_notifications.o rcfile.o  recdone.o recdone_thread.o recstatus.o searchtimer_thread.o services.o switchtimer.o switchtimer_thread.o templatefile.o timer_thread.o timerdone.o timerstatus.o uservars.o varparser.o
 
-ifeq ($(REGEXLIB), pcre)
-LIBS += $(shell pcre-config --libs-posix)
-#LIBS += -L/usr/lib -lpcreposix -lpcre
-INCLUDE += $(shell pcre-config --cflags)
-DEFINES += -DHAVE_PCREPOSIX
+ifeq ($(REGEXLIB), pcre2)
+LIBS += $(shell pcre2-config --libs-posix)
+#LIBS += -L/usr/lib -lpcre2posix -lpcre2
+INCLUDE += $(shell pcre2-config --cflags)
+DEFINES += -DHAVE_PCRE2POSIX
 else ifeq ($(REGEXLIB), tre)
 LIBS += -L$(shell $(PKG_CONFIG) --variable=libdir tre) $(shell $(PKG_CONFIG) --libs tre)
 #LIBS += -L/usr/lib -ltre

--- a/epgsearchtools.c
+++ b/epgsearchtools.c
@@ -43,8 +43,8 @@ The project's page is at http://winni.vdr-developer.org/epgsearch
 #include "timerstatus.h"
 #include <langinfo.h>
 
-#ifdef HAVE_PCREPOSIX
-#include <pcreposix.h>
+#ifdef HAVE_PCRE2POSIX
+#include <pcre2posix.h>
 #elif defined(HAVE_LIBTRE)
 #include <tre/regex.h>
 #else


### PR DESCRIPTION
Update to PCRE2 that replaces the API in the original PCRE
library, which is now obsolete and no longer maintained.

Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>