### PR TITLE
Remove dead-code found by Coverity Scan

### DIFF
--- a/changrp.c
+++ b/changrp.c
@@ -258,8 +258,6 @@ void cMenuChannelGroupItem::Set(void)
         channelNr = channelInGroup->channel->Number();
         if (chIntBegin == -1)
             chIntBegin = channelNr;
-        if (chIntEnd == -1)
-            chIntEnd = channelNr;
 
         if (chLast == channelNr - 1)
             chIntEnd = channelNr;

--- a/confdloader.c
+++ b/confdloader.c
@@ -92,11 +92,9 @@ bool cConfDLoader::LoadFile(const char *FileName)
         FILE *f = fopen(FileName, "r");
         if (f) {
             char *s;
-            int line = 0;
             cReadLine ReadLine;
             std::string section;
             while ((s = ReadLine.Read(f)) != NULL) {
-                line++;
                 char *p = strchr(s, '#');
                 if (p)
                     *p = 0;

--- a/epgsearchext.c
+++ b/epgsearchext.c
@@ -673,7 +673,7 @@ char* cSearchExt::BuildFile(const cEvent* pEvent) const
     if (!pEvent)
         return file;
 
-    const char *Subtitle = pEvent ? pEvent->ShortText() : NULL;
+    const char *Subtitle = pEvent->ShortText();
     char SubtitleBuffer[Utf8BufSize(MAX_SUBTITLE_LENGTH)];
     if (isempty(Subtitle)) {
         time_t Start = pEvent->StartTime();
@@ -688,7 +688,6 @@ char* cSearchExt::BuildFile(const cEvent* pEvent) const
 
     if (useEpisode) {
         cString pFile = cString::sprintf("%s~%s", pEvent->Title(), Subtitle);
-        if (file) free(file);
         file = strdup(pFile);
     } else if (pEvent->Title())
         file = strdup(pEvent->Title());
@@ -1373,7 +1372,6 @@ bool cSearchExt::HasContent(int contentID)
 void cSearchExt::SetContentFilter(int* contentStringsFlags)
 {
     // create the hex array of content descriptor IDs
-    string tmp;
     contentsFilter = "";
     for (unsigned int i = 0; contentStringsFlags && i <= CONTENT_DESCRIPTOR_MAX; i++) {
         if (contentStringsFlags[i]) {

--- a/menu_searchresults.c
+++ b/menu_searchresults.c
@@ -661,11 +661,6 @@ void cMenuSearchResultsForBlacklist::SetHelpKeys(bool Force)
 
     bool hasTimer = (NewHelpKeys == 2);
     if (NewHelpKeys != helpKeys || Force) {
-
-        ModeBlueSR nextModeBlue = (ModeBlueSR)(((int)modeBlue + 1) % 3);
-        if (nextModeBlue == showTimerPreview)
-            nextModeBlue = (ModeBlueSR)(((int)nextModeBlue + 1) % 3);
-
         if (toggleKeys == 0)
             SetHelp((EPGSearchConfig.redkeymode == 0 ? (hasTimer ? trVDR("Button$Timer") : trVDR("Button$Record")) : tr("Button$Commands")), m_bSort ? tr("Button$by channel") : tr("Button$by time"), modeYellow == showTitleEpisode ? tr("Button$Episode") : tr("Button$Title"), NULL);
         else

--- a/uservars.h
+++ b/uservars.h
@@ -489,7 +489,6 @@ public:
     cChannelGroupVar() : cInternalVar("chgrp") {}
     string Evaluate(const cEvent* e, bool escapeStrings = false) {
         if (!e) return "";
-        ostringstream os;
         LOCK_CHANNELS_READ;
         const cChannel *channel = Channels->GetByChannelID(e->ChannelID(), true);
         while (channel && !channel->GroupSep())


### PR DESCRIPTION
Remove unused variables, variables set and set again without being used, checking variables that have been previously checked, etc.