### PR TITLE
use free for memory allocated by realloc

### DIFF
--- a/menu_searchresults.c
+++ b/menu_searchresults.c
@@ -788,7 +788,7 @@ bool cMenuSearchResultsForRecs::BuildList()
         qsort(pArray, num, sizeof(cRecording *), CompareRecording);
         for (int a = 0; a < num; a++)
             Add(new cMenuSearchResultsItem(pArray[a]));
-        delete pArray;
+        free(pArray);
     } // Recordinglock must be released before Display() is called
 
     SetHelp(NULL);


### PR DESCRIPTION
This PR fix a possible memory leak. Memory allocated with "realloc" must be free by "free", not "delete".
The issue was found by gcc13 warning.