### PR TITLE
fix Makefile for coreutils >= 9.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,11 @@ install-$(PLUGIN4): libvdr-$(PLUGIN4).so
 
 install-conf:
 	mkdir -p $(DESTDIR)$(CONFDIR)/plugins/$(PLUGIN)/conf.d
-	cp -n conf/* $(DESTDIR)$(CONFDIR)/plugins/$(PLUGIN)
+	@for i in conf/*; do\
+	    if ! [ -e $(DESTDIR)$(CONFDIR)/plugins/$$i ] ; then\
+	        cp -p $$i $(DESTDIR)$(CONFDIR)/plugins/$(PLUGIN);\
+	        fi\
+	    done
 
 install-doc: docs
 	mkdir -p $(DESTDIR)$(MANDIR)/man1


### PR DESCRIPTION
cp -n fails if target file exists with coreutils >= 9.4.
Each make install will fail after first install.
VDR had the same issue, I took the solution from [here](https://www.vdr-portal.de/forum/index.php?thread/135973-announce-vdr-version-2-6-5-freigegeben/&postID=1365432#post1365432) 