### PR TITLE
Fix order of help buttons in conflict check details menu

### DIFF
--- a/menu_conflictcheck.c
+++ b/menu_conflictcheck.c
@@ -227,7 +227,7 @@ void cMenuConflictCheckDetails::SetHelpKeys()
         hasTimer = curTimerObj->timer->HasFlags(tfActive);
         hasEvent = curTimerObj->Event();
     }
-    SetHelp(hasEvent ? tr("Button$Repeats") : NULL, trVDR("Button$On/Off"), hasTimer ? trVDR("Button$Delete") : NULL, tr("Button$Commands"));
+    SetHelp(trVDR("Button$On/Off"), hasEvent ? tr("Button$Repeats") : NULL, hasTimer ? trVDR("Button$Delete") : NULL, tr("Button$Commands"));
 }
 
 cConflictCheckTimerObj* cMenuConflictCheckDetails::CurrentTimerObj(void)


### PR DESCRIPTION
Correct the positioning of the "On/Off" and "Repeats" help buttons to align with the intended order in the conflict check details menu.