### PR TITLE
Makefile: make WITHOUT_xxx variables effective

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,14 +128,18 @@ endif
 ### The object files (add further files here):
 
 ALL = libvdr-$(PLUGIN).so createcats
+INSTALL-LIB = install-$(PLUGIN)
 ifeq ($(WITHOUT_EPGSEARCHONLY), 0)
   ALL += libvdr-$(PLUGIN2).so
+  INSTALL-LIB += install-$(PLUGIN2)
 endif
 ifeq ($(WITHOUT_CONFLICTCHECKONLY), 0)
   ALL += libvdr-$(PLUGIN3).so
+  INSTALL-LIB += install-$(PLUGIN3)
 endif
 ifeq ($(WITHOUT_QUICKSEARCH), 0)
   ALL += libvdr-$(PLUGIN4).so
+  INSTALL-LIB += install-$(PLUGIN4)
 endif
 
 OBJS = afuzzy.o blacklist.o changrp.o confdloader.o conflictcheck.o conflictcheck_thread.o distance.o $(PLUGIN).o epgsearchcats.o epgsearchcfg.o epgsearchext.o epgsearchsetup.o  epgsearchsvdrp.o epgsearchtools.o mail.o md5.o menu_announcelist.o menu_blacklistedit.o menu_blacklists.o menu_commands.o menu_conflictcheck.o menu_deftimercheckmethod.o menu_dirselect.o menu_event.o menu_favorites.o menu_main.o menu_myedittimer.o menu_quicksearch.o menu_recsdone.o menu_search.o menu_searchactions.o menu_searchedit.o menu_searchresults.o menu_searchtemplate.o menu_switchtimers.o menu_templateedit.o menu_timersdone.o menu_whatson.o noannounce.o pending_notifications.o rcfile.o  recdone.o recdone_thread.o recstatus.o searchtimer_thread.o services.o switchtimer.o switchtimer_thread.o templatefile.o timer_thread.o timerdone.o timerstatus.o uservars.o varparser.o
@@ -335,7 +339,7 @@ install-bin: createcats
 
 install: install-lib install-i18n install-conf install-doc install-bin
 
-install-lib: install-$(PLUGIN) install-$(PLUGIN2) install-$(PLUGIN3) install-$(PLUGIN4)
+install-lib: $(INSTALL-LIB)
 
 dist: docs clean
 	@-rm -rf $(TMPDIR)/$(ARCHIVE)


### PR DESCRIPTION
Make use of WITHOUT_xxx variables effective - unwanted plugins will be excluded on compile target "all" and on install target

Before this change, unwanted plugins were unconditionally compiled and installed during “make install” – which defeated the purpose of the WITHOUT_xxx variables.